### PR TITLE
Fix expo app issues

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,11 @@
+# Feature Tasks
+
+The following tasks outline potential new features to make the app production ready.
+
+- [ ] Offline caching of API data using AsyncStorage
+- [ ] Push notifications setup (expo-notifications)
+- [ ] Persistent user sessions with token refresh logic
+- [ ] Add unit tests with Jest and React Native Testing Library
+- [ ] Error monitoring and analytics (e.g. Sentry)
+- [ ] CI/CD pipeline for automated testing and deployment
+

--- a/app/api/client.js
+++ b/app/api/client.js
@@ -1,7 +1,8 @@
 import { create } from "apisauce";
+import settings from "../config/settings";
 
 const apiClient = create({
-  baseURL: "http://192.168.1.9:5000/api",
+  baseURL: settings.apiUrl,
 });
 
 export default apiClient;

--- a/app/api/listings.js
+++ b/app/api/listings.js
@@ -21,7 +21,7 @@ export const addListing = (listing, onUploadProgress) => {
   if (listing.location)
     data.append("location", JSON.stringify(listing.location));
 
-  client.post(endpoint, data, {
+  return client.post(endpoint, data, {
     onUploadProgress: (progress) =>
       onUploadProgress(progress.loaded / progress.total),
   });

--- a/app/config/settings.js
+++ b/app/config/settings.js
@@ -1,0 +1,22 @@
+import Constants from "expo-constants";
+
+const settings = {
+  dev: {
+    apiUrl: "http://192.168.1.9:5000/api",
+  },
+  staging: {
+    apiUrl: "http://staging.example.com/api",
+  },
+  prod: {
+    apiUrl: "https://api.example.com/api",
+  },
+};
+
+const getCurrentSettings = () => {
+  const releaseChannel = Constants.manifest.releaseChannel;
+  if (releaseChannel === "staging") return settings.staging;
+  if (releaseChannel === "prod") return settings.prod;
+  return settings.dev;
+};
+
+export default getCurrentSettings();

--- a/app/hooks/useApi.js
+++ b/app/hooks/useApi.js
@@ -1,20 +1,21 @@
 import { useState } from "react";
 
-export default useApi = (apiFunc) => {
+export default function useApi(apiFunc) {
   const [data, setData] = useState([]);
   const [error, setError] = useState(false);
   const [loading, setLoading] = useState(false);
 
-  const request = async () => {
+  const request = async (...args) => {
     setLoading(true);
-    const response = await apiFunc();
+    const response = await apiFunc(...args);
     setLoading(false);
 
     if (!response.ok) return setError(true);
     setError(false);
 
     setData(response.data);
+    return response;
   };
 
   return { data, error, loading, request };
-};
+}

--- a/app/hooks/useLocation.js
+++ b/app/hooks/useLocation.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import * as Location from "expo-location";
 
-export default useLocation = () => {
+export default function useLocation() {
   const [location, setLocation] = useState();
 
   const getLocation = async () => {
@@ -23,4 +23,4 @@ export default useLocation = () => {
   }, []);
 
   return location;
-};
+}

--- a/app/screens/LoginScreen.js
+++ b/app/screens/LoginScreen.js
@@ -21,7 +21,7 @@ function LoginScreen(props) {
       >
         <AppFormField
           autoCapitalize="none"
-          autoCorrected={false}
+          autoCorrect={false}
           icon="email"
           keyboardType="email-address"
           name="email"
@@ -30,7 +30,7 @@ function LoginScreen(props) {
         />
         <AppFormField
           autoCapitalize="none"
-          autoCorrected={false}
+          autoCorrect={false}
           icon="lock"
           name="password"
           placeholder="Password"

--- a/app/screens/UploadScreen.js
+++ b/app/screens/UploadScreen.js
@@ -16,7 +16,7 @@ function UploadScreen({ onDone, progress = 0, visible = false }) {
             autoPlay
             loop={false}
             onAnimationFinish={onDone}
-            source={"../assets/animations/done.json"}
+            source={require("../assets/animations/done.json")}
             style={styles.animation}
           />
         )}


### PR DESCRIPTION
## Summary
- correct hooks export syntax
- make useApi more general and return response
- switch base URL to environment settings
- add configurable settings
- fix LoginScreen typos
- ensure Lottie animation uses require
- return posting response in listings API

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68400c709628832cbeced3d18cb3c358