### PR TITLE
Fix hooks export and listing API

### DIFF
--- a/app/api/listings.js
+++ b/app/api/listings.js
@@ -21,7 +21,7 @@ export const addListing = (listing, onUploadProgress) => {
   if (listing.location)
     data.append("location", JSON.stringify(listing.location));
 
-  client.post(endpoint, data, {
+  return client.post(endpoint, data, {
     onUploadProgress: (progress) =>
       onUploadProgress(progress.loaded / progress.total),
   });

--- a/app/hooks/useApi.js
+++ b/app/hooks/useApi.js
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-export default useApi = (apiFunc) => {
+export default function useApi(apiFunc) {
   const [data, setData] = useState([]);
   const [error, setError] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -17,4 +17,4 @@ export default useApi = (apiFunc) => {
   };
 
   return { data, error, loading, request };
-};
+}

--- a/app/hooks/useLocation.js
+++ b/app/hooks/useLocation.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import * as Location from "expo-location";
 
-export default useLocation = () => {
+export default function useLocation() {
   const [location, setLocation] = useState();
 
   const getLocation = async () => {
@@ -23,4 +23,4 @@ export default useLocation = () => {
   }, []);
 
   return location;
-};
+}


### PR DESCRIPTION
## Summary
- fix default exports for hooks
- return API response when adding listings

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68400b4f3808832c94e13623ef74d206