### PR TITLE
Add unit tests for hooks and storage

### DIFF
--- a/__tests__/formImagePicker.test.js
+++ b/__tests__/formImagePicker.test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { render, act } from '@testing-library/react-native';
+import { useFormikContext } from 'formik';
+import { AppForm } from '../app/components/forms';
+import FormImagePicker from '../app/components/forms/FormImagePicker';
+import ImageInput from '../app/components/ImageInput';
+
+function ValuesDisplay() {
+  const { values } = useFormikContext();
+  return <Text testID="values">{JSON.stringify(values.images)}</Text>;
+}
+
+describe('FormImagePicker', () => {
+  it('adds and removes images', () => {
+    const { UNSAFE_getAllByType, getByTestId } = render(
+      <AppForm initialValues={{ images: [] }} onSubmit={() => {}}>
+        <FormImagePicker name="images" />
+        <ValuesDisplay />
+      </AppForm>
+    );
+
+    // Add image
+    let inputs = UNSAFE_getAllByType(ImageInput);
+    act(() => inputs[0].props.onChangeImage('img1'));
+    expect(getByTestId('values').props.children).toContain('img1');
+
+    // Remove image
+    inputs = UNSAFE_getAllByType(ImageInput);
+    act(() => inputs[0].props.onChangeImage());
+    expect(getByTestId('values').props.children).not.toContain('img1');
+  });
+});

--- a/__tests__/storage.test.js
+++ b/__tests__/storage.test.js
@@ -1,0 +1,31 @@
+import storage from '../app/auth/storage';
+jest.mock('expo-secure-store', () => ({
+  setItemAsync: jest.fn(),
+  getItemAsync: jest.fn(),
+  deleteItemAsync: jest.fn(),
+}), { virtual: true });
+
+import * as SecureStore from 'expo-secure-store';
+
+describe('auth storage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('stores the token', async () => {
+    await storage.storeToken('abc');
+    expect(SecureStore.setItemAsync).toHaveBeenCalledWith('authToken', 'abc');
+  });
+
+  it('gets the token', async () => {
+    SecureStore.getItemAsync.mockResolvedValue('123');
+    const token = await storage.getToken();
+    expect(SecureStore.getItemAsync).toHaveBeenCalledWith('authToken');
+    expect(token).toBe('123');
+  });
+
+  it('removes the token', async () => {
+    await storage.removeToken();
+    expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('authToken');
+  });
+});

--- a/__tests__/useApi.test.js
+++ b/__tests__/useApi.test.js
@@ -1,0 +1,60 @@
+import { renderHook, act } from '@testing-library/react-native';
+import useApi from '../app/hooks/useApi';
+import cache from '../app/utility/cache';
+
+jest.mock('../app/utility/cache');
+
+const successResponse = { ok: true, data: { foo: 'bar' } };
+const errorResponse = { ok: false };
+
+describe('useApi hook', () => {
+  it('stores data on success', async () => {
+    const apiFunc = jest.fn().mockResolvedValue(successResponse);
+    const { result } = renderHook(() => useApi(apiFunc));
+
+    await act(async () => {
+      await result.current.request();
+    });
+
+    expect(apiFunc).toHaveBeenCalled();
+    expect(result.current.data).toEqual(successResponse.data);
+    expect(result.current.error).toBe(false);
+  });
+
+  it('sets error on failure', async () => {
+    const apiFunc = jest.fn().mockResolvedValue(errorResponse);
+    const { result } = renderHook(() => useApi(apiFunc));
+
+    await act(async () => {
+      await result.current.request();
+    });
+
+    expect(result.current.error).toBe(true);
+  });
+
+  it('reads from cache first when key provided', async () => {
+    cache.get.mockResolvedValue({ foo: 'cached' });
+    const apiFunc = jest.fn().mockResolvedValue(successResponse);
+    const { result } = renderHook(() => useApi(apiFunc, 'test')); 
+
+    await act(async () => {
+      await result.current.request();
+    });
+
+    expect(cache.get).toHaveBeenCalledWith('test');
+    // Should set cached data before api call resolves
+    expect(result.current.data).toEqual(successResponse.data);
+  });
+
+  it('stores response in cache when key provided', async () => {
+    cache.get.mockResolvedValue(null);
+    const apiFunc = jest.fn().mockResolvedValue(successResponse);
+    const { result } = renderHook(() => useApi(apiFunc, 'key'));
+
+    await act(async () => {
+      await result.current.request();
+    });
+
+    expect(cache.store).toHaveBeenCalledWith('key', successResponse.data);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "react-native-screens": "~3.4.0",
     "react-native-vector-icons": "^8.1.0",
     "react-native-web": "~0.13.12",
-    "yup": "^0.32.9"
-    "@babel/core": "~7.9.0",
+    "yup": "^0.32.9",
+    "@babel/core": "^7.22.6",
     "@testing-library/jest-native": "^4.0.4",
     "@testing-library/react-native": "^9.1.0",
     "jest-expo": "^42.0.0"


### PR DESCRIPTION
## Summary
- update `@babel/core` so Jest works
- add tests for the `useApi` hook
- add tests for auth storage helpers
- add tests for `FormImagePicker`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840326a8de4832c8cd0ee212ecb2748